### PR TITLE
bump containers bound

### DIFF
--- a/interval-patterns.cabal
+++ b/interval-patterns.cabal
@@ -17,7 +17,7 @@ description:
 common interval-patterns
   build-depends:
     , base                >=4.11    && <5
-    , containers          >=0.6.7   && <0.8
+    , containers          >=0.6.7   && <0.9
     , deepseq             >=1.4.8   && <1.6
     , groups              >=0.5.3   && <0.6
     , hashable            >=1.4.2   && <1.6


### PR DESCRIPTION
Hey, long time no see!

Tested with this `cabal.project.local`:

```
with-compiler: ghc-9.10.2
constraints: containers ==0.8
allow-newer:
    indexed-traversable:containers,
    lattices:containers,
    universe-reverse-instances:containers,
    universe-base:containers,
    hashable:containers,
```